### PR TITLE
Prevent Errors using using other testing frameworks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 1.2.3
+
+- Fixes crash when karmaConfig doesn't exist for some projects in angular.json
+
 ### Version 1.2.2
 
 - Make breakpoints working when debugging tests

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "img/test-explorer_icon.png",
   "author": "Patricio Ferraggi <pattferraggi@gmail.com>",
   "publisher": "raagh",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/core/angular/angular-project-config-loader.ts
+++ b/src/core/angular/angular-project-config-loader.ts
@@ -61,7 +61,7 @@ export class AngularProjectConfigLoader {
     const projects: AngularProject[] = [];
     for (const projectName of Object.keys(angularJsonObject.projects)) {
       const projectConfig = angularJsonObject.projects[projectName];
-      if (projectConfig.architect.test === undefined) {
+      if (projectConfig.architect.test === undefined || projectConfig.architect.test.options.karmaConfig  === undefined) {
         continue;
       }
 


### PR DESCRIPTION
When using NX you may have additional apps (like NestJS) which use other testing frameworks like Jest. So the extension shouldn't error out with `The "path" argument must be of type string. Received type undefined` just because karmaConfig is missing.