### PR TITLE
Fix path detection not working with some workspaces

### DIFF
--- a/src/model/test-explorer-configuration.ts
+++ b/src/model/test-explorer-configuration.ts
@@ -2,7 +2,7 @@ import path = require("path");
 
 export class TestExplorerConfiguration {
   public constructor(config: any, workspaceVSCODEPath: string) {
-    const workspacePath = workspaceVSCODEPath.replace(/^\/([a-z]):\//, "$1:/");
+    const workspacePath = workspaceVSCODEPath.replace(/^\/([A-Za-z]):\//, "$1:/");
     const projectRootPath = config.get("projectRootPath") as string;
     const karmaConfFilePath = config.get("karmaConfFilePath") as string;
     this.defaultAngularProjectName = config.get("defaultAngularProjectName") as string;


### PR DESCRIPTION
Fixes  #62

This PR enhances the projectRootPath extraction logic for cases where the workspace path returned by VSCode contains an uppercase drive letter instead of a lowercase one.