### PR TITLE
Remove Debugger for Chrome dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### [Unreleased]
+
+- Remove Debugger for Chrome dependency
+
 ### Version 1.2.5
 
 - Update npm dependencies

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -20,14 +20,14 @@ List of currently used properties:
 | `angularKarmaTestExplorer.karmaConfFilePath`           | The path where the karma.conf.js is located (relative to the angular project folder)                                                           |
 | `angularKarmaTestExplorer.projectType`                 | Setup the type of project you re using('AngularCLI', 'Angular' or 'Karma'). Default value is AngularCLI                                        |
 | `angularKarmaTestExplorer.angularProcessCommand`       | If you run angular with a specific configuration in your ng test command you can setup it here                                                 |
-| `angularKarmaTestExplorer.debuggerConfiguration`       | If the current Debugger For Chrome configuration doesn't work for you, here you can enter your own                                             |
+| `angularKarmaTestExplorer.debuggerConfiguration`       | If the current debugger for Chrome configuration doesn't work for you, here you can enter your own                                             |
 
-Default VSCode Chrome Debugger configuration:
+Default VSCode Chrome debugger configuration:
 
 ```json
 {
   "name": "Debug tests",
-  "type": "chrome",
+  "type": "pwa-chrome",
   "request": "attach",
   "port": 9222,
   "sourceMaps": true,
@@ -42,7 +42,7 @@ Default VSCode Chrome Debugger configuration:
 }
 ```
 
-No validation is done to the debugger configuration, is your responsibility to setup something that works.
+No validation is done to the debugger configuration, is your responsibility to setup something that works. You can find documentation for VSCode's JavaScript debugger options [here](https://github.com/microsoft/vscode-js-debug/blob/master/OPTIONS.md).
 
 Port 9999 is used as default for connecting the vscode instance and the karma instance. If you want to use a different port you can change it by
 setting the following property:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Angular/Karma Test Explorer for Visual Studio Code
 
 The `Angular/Karma Test Explorer` extension allows you to run or debug your Angular or Karma tests with the
-[Test Explorer UI](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer) and
-the [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) extensions on Visual Studio Code.
+[Test Explorer UI](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer) extension on Visual Studio Code.
 
 ![Example run tests](img/img-running-tests-readme.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-karma-test-explorer",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,8 +83,7 @@
     "vscode": "^1.23.0"
   },
   "extensionDependencies": [
-    "hbenl.vscode-test-explorer",
-    "msjsdiag.debugger-for-chrome"
+    "hbenl.vscode-test-explorer"
   ],
   "activationEvents": [
     "*"
@@ -147,7 +146,7 @@
           "scope": "resource",
           "default": {
             "name": "Debug tests",
-            "type": "chrome",
+            "type": "pwa-chrome",
             "request": "attach",
             "port": 9222,
             "sourceMaps": true,


### PR DESCRIPTION
Addresses issue #87 to remove the now unneeded dependency on the [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) extension.

* Removes it as an extension dependency in the `package.json` file.
* Updates the debugger type from `chome` to `pwa-chrome` used by the VSCode built-in replacement extension.
* Updates the readme and documentation accordingly to reflect the removed dependency.