### PR TITLE
fix broken npx cmd on linux

### DIFF
--- a/src/core/angular/angular-process-configurator.ts
+++ b/src/core/angular/angular-process-configurator.ts
@@ -3,7 +3,7 @@ import { FileHelper } from "../integration/file-helper";
 import { window } from "vscode";
 
 export class AngularProcessConfigurator {
-  public constructor(private readonly fileHelper: FileHelper) {}
+  public constructor(private readonly fileHelper: FileHelper) { }
 
   public createProcessOptions(projectRootPath: string, userKarmaConfigPath: string, defaultSocketPort: number) {
     const testExplorerEnvironment = Object.create(process.env);
@@ -44,7 +44,7 @@ export class AngularProcessConfigurator {
       cliArgs = commonArgs;
       cliCommand = "ng";
     } else if (isAngularInstalledLocally) {
-      cliArgs = ["@angular/cli", ...commonArgs];
+      cliArgs = ["-p", "@angular/cli", ...commonArgs];
       cliCommand = "npx";
     } else {
       const error = "@angular/cli is not installed, install it and restart vscode";


### PR DESCRIPTION
According to the gitter chat (https://gitter.im/Angular-Karma-Test-Explorer/Bugs) on systems with mono cli installed executing `npx @angular/cli test ...` results in the following errror: `Cannot open assembly 'test': File does not contain a valid CIL image.`. Thus I inserted `-p` between npx and the called package as suggested by marksvc in the chat. That should hopefully fix the infinite loading of tests. The npx docu also suggests this usage: https://github.com/npm/npx#readme