### PR TITLE
Adding visibility to hangups around launching Karma

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,6 +6,7 @@
 - Run your tests using the ![Run](img/run.png) icon.
 - Debug tests by setting breakpoints in your code and press the ![Debug](img/debug.png) icon to start debugging.
 - If a test failed click on it and you will see the fail information on vscode `Test Explorer` output channel, or gutter decorations inside the spec file.
+- NOTE: for Angular CLI projects, this will only run the 'test' architect target. 
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-karma-test-explorer",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3214,9 +3214,9 @@
       }
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -3298,9 +3298,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -4603,9 +4603,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -5744,9 +5744,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -7283,9 +7283,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "clean": "rimraf out *.vsix",
     "build": "tsc",
-    "watch": "tsc -w",
+    "watch": "tsc -w --sourceMap",
     "rebuild": "npm run clean && npm run build",
     "prettify": "npx prettier --write '**/*.ts'",
     "package": "npx vsce package",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/socket.io-client": "^1.4.32",
     "jest": "^24.9.0",
     "jest-when": "^2.7.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.20",
     "ts-jest": "^24.1.0",
     "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.18.0",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -25,7 +25,7 @@ export class Adapter implements TestAdapter {
   private readonly testExplorer: AngularKarmaTestExplorer;
   private readonly debugger: Debugger;
   private isTestProcessRunning: boolean = false;
-  public loadedTests: TestSuiteInfo = {} as TestSuiteInfo;
+  public loadedTests: TestSuiteInfo | undefined;
 
   get tests(): vscode.Event<TestLoadStartedEvent | TestLoadFinishedEvent> {
     return this.testsEmitter.event;

--- a/src/core/angular-karma-test-explorer.ts
+++ b/src/core/angular-karma-test-explorer.ts
@@ -16,9 +16,9 @@ export class AngularKarmaTestExplorer {
     private readonly karmaEventListener: KarmaEventListener
   ) {}
 
-  public async loadTests(config: TestExplorerConfiguration): Promise<TestSuiteInfo> {
+  public async loadTests(config: TestExplorerConfiguration): Promise<TestSuiteInfo | undefined> {
     if (!this.testServerValidation.isValidProject(config.projectRootPath, config.projectType)) {
-      return {} as TestSuiteInfo;
+      return undefined;
     }
 
     if (this.karmaRunner.isKarmaRunning()) {

--- a/src/infrastructure/ioc-container.ts
+++ b/src/infrastructure/ioc-container.ts
@@ -20,12 +20,15 @@ import * as vscode from "vscode";
 import { Debugger } from "../core/test-explorer/debugger";
 
 export class IOCContainer {
+
   public constructor(private readonly channel: vscode.OutputChannel, private readonly isDebugMode: boolean) {}
+  
   public registerTestExplorerDependencies(
     eventEmitterInterface: vscode.EventEmitter<TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent>,
     testLoadedEmitterInterface: vscode.EventEmitter<TestLoadStartedEvent | TestLoadFinishedEvent>,
     projectType: ProjectType
   ): AngularKarmaTestExplorer {
+
     // poor man's dependency injection
     const fileHelper = new FileHelper();
     const karmaHelper = new TestServerValidation(fileHelper);


### PR DESCRIPTION
- Adding periodic log messages while waiting to connect to Karma, to help users better understand where things are stuck
- Return undefined, rather than {}, to avoid the Test Explorer throwing a bunch of errors
- Running npm audit fix
- Adding source maps to debug config
