### PR TITLE
fix: npx installs @angular/cli instead of running locally

### DIFF
--- a/src/core/angular/angular-process-configurator.ts
+++ b/src/core/angular/angular-process-configurator.ts
@@ -44,7 +44,7 @@ export class AngularProcessConfigurator {
       cliArgs = commonArgs;
       cliCommand = "ng";
     } else if (isAngularInstalledLocally) {
-      cliArgs = ["@angular/cli", ...commonArgs];
+      cliArgs = ["ng", ...commonArgs];
       cliCommand = "npx";
     } else {
       const error = "@angular/cli is not installed, install it and restart vscode";


### PR DESCRIPTION
When @angular/cli is installed locally, to run ng the command is `npx ng ...`

`npx @angular/cli ...` will attempt to install @angular/cli

Fixes #101