### PR TITLE
Fix showing the decorator on the correct line

### DIFF
--- a/__tests__/core/shared/event-emitter.tests.ts
+++ b/__tests__/core/shared/event-emitter.tests.ts
@@ -101,7 +101,7 @@ test("should emit correctly a test result event with test decorations", () => {
       test: testName,
       state: TestState.Passed,
       message: "Expected 'test-project' to equal 'test-projectsdsdsd'. (line:22 column:23)",
-      decorations: [{ line: 22, message: "Expected 'test-project' to equal 'test-projectsdsdsd'." }],
+      decorations: [{ line: 21, message: "Expected 'test-project' to equal 'test-projectsdsdsd'." }],
     } as TestEvent)
   );
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "img/test-explorer_icon.png",
   "author": "Patricio Ferraggi <pattferraggi@gmail.com>",
   "publisher": "raagh",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/core/shared/event-emitter.ts
+++ b/src/core/shared/event-emitter.ts
@@ -77,12 +77,12 @@ export class EventEmitter {
         const errorLineAndColumnCollection = failureMessage.substring(failureMessage.indexOf(results.filePath as string)).split(":");
         const lineNumber = parseInt(errorLineAndColumnCollection[1], undefined);
         return {
-          line: lineNumber,
+          line: lineNumber - 1,
           message: failureMessage.split("\n")[0],
         };
       });
 
-      if (decorations.some(x => isNaN(x.line))) {
+      if (decorations.some((x) => isNaN(x.line))) {
         return undefined;
       }
 


### PR DESCRIPTION
While using this extension I was confused with the position of the test result. I saw that someone had created an  for this already, see issue #94.

After some investigation, I figured out that the line index of a file starts at 0. 
That means that if you get an error that says that the issue is on line 55, that's actually on 54.